### PR TITLE
Handle empty folders

### DIFF
--- a/pages/folder/index.js
+++ b/pages/folder/index.js
@@ -44,11 +44,15 @@ export default class FolderPage extends React.PureComponent {
                 <Header>
                   <ShapeComponents components={folder.components} />
                 </Header>
-                <List>
-                  {children.map(p => (
-                    <CategoryItem key={p.id} data={p} />
-                  ))}
-                </List>
+                {children ? (
+                  <List>
+                    {children.map(p => (
+                      <CategoryItem key={p.id} data={p} />
+                    ))}
+                  </List>
+                ) : (
+                  'This folder is empty'
+                )}
               </Outer>
             </Layout>
           );


### PR DESCRIPTION
This PR checks whether folders have children, and if there are no children it renders a message saying the folder is empty. Trying to open a folder with no children resulted in the following stack trace. Unsure if it's the same issue, but could be related to #7.

```
TypeError: Cannot read property 'map' of null
        at Object.children (/Users/brendan/projects/telescope-store/.next/server/static/development/pages/folder.js:8617:132)
        at finish (/Users/brendan/projects/telescope-store/node_modules/react-apollo/react-apollo.cjs.js:353:55)
        at Query.render (/Users/brendan/projects/telescope-store/node_modules/react-apollo/react-apollo.cjs.js:357:16)
        at processChild (/Users/brendan/projects/telescope-store/node_modules/react-dom/cjs/react-dom-server.node.development.js:2959:18)
        at resolve (/Users/brendan/projects/telescope-store/node_modules/react-dom/cjs/react-dom-server.node.development.js:2812:5)
        at ReactDOMServerRenderer.render (/Users/brendan/projects/telescope-store/node_modules/react-dom/cjs/react-dom-server.node.development.js:3202:22)
        at ReactDOMServerRenderer.read (/Users/brendan/projects/telescope-store/node_modules/react-dom/cjs/react-dom-server.node.development.js:3161:29)
        at renderToString (/Users/brendan/projects/telescope-store/node_modules/react-dom/cjs/react-dom-server.node.development.js:3646:27)
        at render (/Users/brendan/projects/telescope-store/node_modules/next-server/dist/server/render.js:80:16)
        at renderPage (/Users/brendan/projects/telescope-store/node_modules/next-server/dist/server/render.js:237:20)
        at ctx.renderPage (/Users/brendan/projects/telescope-store/.next/server/static/development/pages/_document.js:1119:30)
        at /Users/brendan/projects/telescope-store/.next/server/static/development/pages/_document.js:532:17
        at Generator.next (<anonymous>)
        at asyncGeneratorStep (/Users/brendan/projects/telescope-store/.next/server/static/development/pages/_document.js:228:24)
        at _next (/Users/brendan/projects/telescope-store/.next/server/static/development/pages/_document.js:250:9)
        at /Users/brendan/projects/telescope-store/.next/server/static/development/pages/_document.js:257:7
    Error while running `getDataFromTree` TypeError: Cannot read property 'map' of null
```

![](https://media0.giphy.com/media/yy1RLVzuSAiFa/giphy.gif)