### PR TITLE
Bump apollo-boost to ^0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@crystallize/node-klarna": "^2.1.1",
     "@crystallize/react-image": "^3.0.0-beta.7",
     "@crystallize/react-layout": "^3.0.0",
-    "apollo-boost": "^0.3.1",
+    "apollo-boost": "^0.4.3",
     "apollo-cache-inmemory": "^1.5.1",
     "apollo-client": "^2.5.1",
     "babel-plugin-module-resolver": "^3.2.0",


### PR DESCRIPTION
With `apollo-boost@0.3.1` starting the app with Node 12 via `yarn dev` or `npm run dev` causes the following error:

```
> yarn dev
yarn run v1.16.0
$ node ./index.js
/Users/brendan/projects/telescope-store/node_modules/apollo-boost/lib/bundle.cjs.js:127
Object.keys(ApolloClient__default).forEach(function (key) { exports[key] = ApolloClient__default[key]; });
                                                                         ^

TypeError: Cannot assign to read only property '__esModule' of object '#<Object>'
    at /Users/brendan/projects/telescope-store/node_modules/apollo-boost/lib/bundle.cjs.js:127:74
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/Users/brendan/projects/telescope-store/node_modules/apollo-boost/lib/bundle.cjs.js:127:36)
    at Module._compile (internal/modules/cjs/loader.js:777:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:788:10)
    at Module.load (internal/modules/cjs/loader.js:643:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Module.require (internal/modules/cjs/loader.js:683:19)
    at require (internal/modules/cjs/helpers.js:16:16)
    at Object.<anonymous> (/Users/brendan/projects/telescope-store/lib/init-apollo.js:2:36)
error Command failed with exit code 1.
```

It runs correctly with `apollo-boost@0.4.3`.