### PR TITLE
Fix selected variant state

### DIFF
--- a/pages/product/index.js
+++ b/pages/product/index.js
@@ -119,6 +119,7 @@ const ProductPageDataLoader = props => {
         return (
           <Layout title={product.name}>
             <ProductPage
+              key={product.id}
               product={product}
               defaultVariant={defaultVariant}
               {...props}


### PR DESCRIPTION
Currently the state for the selected variant isn't always updated when switching product, causing the product from the previous page to still show. Adding a `key` when rendering the `ProductPage` component fixes this.

Old:
![Kapture 2019-08-09 at 11 17 30](https://user-images.githubusercontent.com/8467879/62751539-33f5b400-bab8-11e9-9586-53c90f90ee79.gif)

New:
![Kapture 2019-08-09 at 15 16 59](https://user-images.githubusercontent.com/8467879/62751695-c433f900-bab8-11e9-8734-bdac8958493d.gif)
