### PR TITLE
Render the image of the default variant in CategoryItem

### DIFF
--- a/components/category-item/index.js
+++ b/components/category-item/index.js
@@ -28,7 +28,9 @@ class CategoryItem extends React.Component {
       );
     }
 
-    const [{ price, image }] = variants || [];
+    const { price, image } = variants
+      ? variants.find(variant => variant.isDefault)
+      : {};
 
     return (
       <Link as={path} key={key} href={`/${type}`} passHref>


### PR DESCRIPTION
This fixes rendering the placeholder image when only the default variant has an image attached.