### PR TITLE
Fix checkout flow and products with Express

### DIFF
--- a/lib/get-component-and-data-for-path.js
+++ b/lib/get-component-and-data-for-path.js
@@ -57,7 +57,7 @@ async function getComponentForPath({ pathname, language }) {
     }
 
     return {
-      component: '/catalog',
+      component: '/catalogue',
       urqlState
     };
   } catch (error) {

--- a/lib/graph/queries/order-by-id.js
+++ b/lib/graph/queries/order-by-id.js
@@ -1,5 +1,5 @@
 module.exports = `
-  query getOrder($id: String!){
+  query getOrder($id: ID!){
     orders {
       get(id: $id) {
         id

--- a/lib/util/cart-validation.js
+++ b/lib/util/cart-validation.js
@@ -1,7 +1,7 @@
 const { request } = require('graphql-request');
 const { GRAPH_URL } = require('../../config');
 
-export const validateItems = lineItems =>
+const validateItems = lineItems =>
   new Promise(async (resolve, reject) => {
     const uniqueLineItems = lineItems.reduce(
       (unique, val) =>
@@ -43,3 +43,7 @@ export const validateItems = lineItems =>
       reject(error);
     }
   });
+
+module.exports = {
+  validateItems
+};

--- a/page-components/checkout/stripe.js
+++ b/page-components/checkout/stripe.js
@@ -26,6 +26,7 @@ class StripeWrapper extends React.Component {
 
     const { client_secret } = await fetch('/api/stripe/create-payment-intent', {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         currency,
         lineItems

--- a/pages/api/stripe/create-payment-intent.js
+++ b/pages/api/stripe/create-payment-intent.js
@@ -3,7 +3,7 @@ const { validateItems } = require('../../../lib/util/cart-validation');
 
 export default async (req, res) => {
   try {
-    const { lineItems, currency } = JSON.parse(req.body);
+    const { lineItems, currency } = req.body;
     const validatedItems = await validateItems(lineItems);
     const amount = validatedItems.reduce((acc, val) => {
       return acc + val.price * val.quantity;

--- a/pages/confirmation/index.js
+++ b/pages/confirmation/index.js
@@ -26,8 +26,10 @@ class Confirmation extends React.Component {
   };
 
   static async getInitialProps({ req }) {
-    const { orderId, paymentMethod } = req.params;
-    if (orderId) return { orderId, paymentMethod };
+    if (req.params && req.params.orderId) {
+      const { orderId, paymentMethod } = req.params;
+      return { orderId, paymentMethod };
+    }
 
     const { query } = queryString.parseUrl(req.url);
     return { orderId: query.order_id, paymentMethod: query.payment_method };

--- a/pages/confirmation/index.js
+++ b/pages/confirmation/index.js
@@ -26,6 +26,9 @@ class Confirmation extends React.Component {
   };
 
   static async getInitialProps({ req }) {
+    const { orderId, paymentMethod } = req.params;
+    if (orderId) return { orderId, paymentMethod };
+
     const { query } = queryString.parseUrl(req.url);
     return { orderId: query.order_id, paymentMethod: query.payment_method };
   }

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -1,10 +1,10 @@
 const router = require('express').Router();
-const bodyParser = require('body-parser');
 const magicLink = require('./magic-link');
 const authenticate = require('./authenticate');
 const verify = require('./verify');
 const orderPersistence = require('./order-persistence');
 const orderConfirmation = require('./order-confirmation');
+const createPaymentIntent = require('./stripe/create-payment-intent');
 
 // @extraStripe
 // Provides stripe with the Raw body it needs to handle webhook event signatures
@@ -17,12 +17,12 @@ const orderConfirmation = require('./order-confirmation');
 //   }
 // })
 // )
-router.use(bodyParser.json());
 
 router.get('/magic-link/:email', magicLink);
 router.get('/authenticate', authenticate);
 router.get('/verify/:token', verify);
 router.post('/order-persistence', orderPersistence);
 router.post('/order-confirmation', orderConfirmation);
+router.post('/stripe/create-payment-intent', createPaymentIntent);
 
 module.exports = router;

--- a/server/api/order-persistence.js
+++ b/server/api/order-persistence.js
@@ -7,36 +7,46 @@ const klarnaOrderAcknowledger = require('../../lib/util/klarna-order-acknowledge
 module.exports = async (req, res) => {
   // TODO: Handle understanding the payment method by some body fields e.g. stripe has customer_id
   let paymentMethod;
+  let response;
   const data = req.body;
+
   try {
-    const paymentIntent = data.payment_intent;
+    const { paymentIntentId } = data;
+
     // @extraStripe
     const sig = req.headers['stripe-signature'];
 
-    if (paymentIntent || sig) paymentMethod = 'stripe';
-    if (data.merchant_urls) paymentMethod = 'klarna';
+    if (paymentIntentId || sig) paymentMethod = 'stripe';
+    if (req.query.klarna_order_id) paymentMethod = 'klarna';
+
+    if (!paymentMethod) {
+      return res.status(200).send({
+        success: true,
+        message: 'No payment method seems to be selected'
+      });
+    }
 
     const mutationBody = await orderQueryNormalizer(data, paymentMethod, {
       // @extraStripe
       stripeSignature: sig,
 
-      paymentIntentId: paymentIntent,
+      paymentIntentId,
       stripeRawBody: req.rawBody,
-      klarnaOrderId: req.params.klarna_order_id
+      klarnaOrderId: req.query.klarna_order_id
     });
-    const response = await createCrystallizeOrder(mutationBody);
+
+    response = await createCrystallizeOrder(mutationBody);
 
     if (paymentMethod === 'klarna')
-      await klarnaOrderAcknowledger(req.params.klarna_order_id);
-
-    res.status(200).send({
-      success: true,
-      ...response
-    });
+      await klarnaOrderAcknowledger(req.query.klarna_order_id);
   } catch (error) {
-    res.status(503).send({
+    return res.status(503).send({
       success: false,
-      ...error
+      error: error.stack
     });
   }
+  return res.status(200).send({
+    success: true,
+    ...response
+  });
 };

--- a/server/api/stripe/create-payment-intent.js
+++ b/server/api/stripe/create-payment-intent.js
@@ -1,0 +1,24 @@
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+const { validateItems } = require('../../../lib/util/cart-validation');
+
+module.exports = async (req, res) => {
+  try {
+    const { lineItems, currency } = req.body;
+    const validatedItems = await validateItems(lineItems);
+    const amount = validatedItems.reduce((acc, val) => {
+      return acc + val.price * val.quantity;
+    }, 0);
+
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: amount * 100,
+      currency
+    });
+
+    return res.json(paymentIntent);
+  } catch (error) {
+    return res.status(503).send({
+      success: false,
+      error: error.stack
+    });
+  }
+};

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 
 const express = require('express');
+const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const helmet = require('helmet');
 const next = require('next');
@@ -17,6 +18,8 @@ app.prepare().then(() => {
   const server = express();
   server.use(helmet());
   server.use(cookieParser());
+  server.use(bodyParser.urlencoded({ extended: false }));
+  server.use(bodyParser.json());
   server.use('/api', api);
 
   // Helper function for throwing 404's from Next pages

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,10 @@ app.prepare().then(() => {
   server.use(bodyParser.json());
   server.use('/api', api);
 
+  server.get('/confirmation/:orderId', (req, res) => {
+    app.render(req, res, '/confirmation', { orderId: req.params.orderId });
+  });
+
   // Helper function for throwing 404's from Next pages
   server.get('*', async (req, res, doNext) => {
     req.throw404 = function throw404() {


### PR DESCRIPTION
This PR fixes some rendering issues, as well as the checkout and order confirmation flow when using Express instead of Now.

- [x] Fixes GraphQL query to retrieve an order by id
- [x] Fixes rendering catalogue items with Express
- [x] Fixes Stripe checkout with Express
- [x] Fixes order confirmation page with Express
- [x] Fixes order persistence with Express

Klarna endpoints are still missing from the Express implementation and should be added in the near future.